### PR TITLE
Add Specializations page with Cardiology subpage

### DIFF
--- a/src/Pages/Employees.cshtml
+++ b/src/Pages/Employees.cshtml
@@ -1,0 +1,152 @@
+@page
+@model EmployeesModel
+@{
+    ViewData["Title"] = "Employee Directory";
+}
+
+<style>
+    .employee-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .employee-title {
+        color: #2c3e50;
+        text-align: center;
+        margin-bottom: 30px;
+        font-size: 2.5rem;
+        font-weight: bold;
+    }
+
+    .employee-table {
+        width: 100%;
+        border-collapse: collapse;
+        box-shadow: 0 2px 15px rgba(0,0,0,0.1);
+        background-color: white;
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .employee-table thead {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+    }
+
+    .employee-table th {
+        padding: 15px;
+        text-align: left;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.9rem;
+        letter-spacing: 0.5px;
+    }
+
+    .employee-table tbody tr {
+        border-bottom: 1px solid #ecf0f1;
+        transition: all 0.3s ease;
+    }
+
+    .employee-table tbody tr:hover {
+        background-color: #f8f9fa;
+        transform: scale(1.01);
+        box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    }
+
+    .employee-table tbody tr:last-child {
+        border-bottom: none;
+    }
+
+    .employee-table td {
+        padding: 15px;
+        color: #2c3e50;
+    }
+
+    .employee-table tbody tr:nth-child(even) {
+        background-color: #f8f9fa;
+    }
+
+    .department-badge {
+        display: inline-block;
+        padding: 5px 12px;
+        border-radius: 20px;
+        font-size: 0.85rem;
+        font-weight: 500;
+    }
+
+    .dept-engineering {
+        background-color: #e3f2fd;
+        color: #1976d2;
+    }
+
+    .dept-sales {
+        background-color: #f3e5f5;
+        color: #7b1fa2;
+    }
+
+    .dept-marketing {
+        background-color: #fff3e0;
+        color: #f57c00;
+    }
+
+    .dept-hr {
+        background-color: #fce4ec;
+        color: #c2185b;
+    }
+
+    .dept-finance {
+        background-color: #e8f5e9;
+        color: #388e3c;
+    }
+
+    .dept-support {
+        background-color: #fff9c4;
+        color: #f57f17;
+    }
+
+    .dept-product {
+        background-color: #e0f2f1;
+        color: #00796b;
+    }
+</style>
+
+<div class="employee-container">
+    <h1 class="employee-title">@ViewData["Title"]</h1>
+    
+    @if (Model.Employees != null && Model.Employees.Any())
+    {
+        <table class="employee-table">
+            <thead>
+                <tr>
+                    <th>First Name</th>
+                    <th>Last Name</th>
+                    <th>Hiring Date</th>
+                    <th>Department</th>
+                    <th>Job Title</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var employee in Model.Employees)
+                {
+                    <tr>
+                        <td>@employee.FirstName</td>
+                        <td>@employee.LastName</td>
+                        <td>@DateTime.Parse(employee.HiringDate).ToString("MMMM dd, yyyy")</td>
+                        <td>
+                            @{
+                                var deptClass = employee.Department.Replace(" ", "").ToLower();
+                                var badgeClass = $"department-badge dept-{deptClass}";
+                            }
+                            <span class="@badgeClass">@employee.Department</span>
+                        </td>
+                        <td>@employee.JobTitle</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p class="text-center">No employee data available.</p>
+    }
+</div>

--- a/src/Pages/Employees.cshtml.cs
+++ b/src/Pages/Employees.cshtml.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Text.Json;
+
+namespace contosohealth.Pages;
+
+public class EmployeeDto
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string HiringDate { get; set; } = string.Empty;
+    public string Department { get; set; } = string.Empty;
+    public string JobTitle { get; set; } = string.Empty;
+}
+
+public class EmployeesModel : PageModel
+{
+    private readonly ILogger<EmployeesModel> _logger;
+    private readonly IWebHostEnvironment _environment;
+
+    public List<EmployeeDto> Employees { get; set; } = new List<EmployeeDto>();
+
+    public EmployeesModel(ILogger<EmployeesModel> logger, IWebHostEnvironment environment)
+    {
+        _logger = logger;
+        _environment = environment;
+    }
+
+    public void OnGet()
+    {
+        var jsonPath = Path.Combine(_environment.ContentRootPath, "sampledata.json");
+        if (System.IO.File.Exists(jsonPath))
+        {
+            var jsonData = System.IO.File.ReadAllText(jsonPath);
+            Employees = JsonSerializer.Deserialize<List<EmployeeDto>>(jsonData) ?? new List<EmployeeDto>();
+        }
+    }
+}

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -29,8 +29,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Doctors">Doctors</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                        <li class="nav-item">                            <a class="nav-link text-dark" asp-area="" asp-page="/Specializations">Specializations</a>
+                        </li>
+                        <li class="nav-item">                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                         </li>
                     </ul>
                     <ul class="navbar-nav">

--- a/src/Pages/Specializations.cshtml
+++ b/src/Pages/Specializations.cshtml
@@ -1,0 +1,181 @@
+@page
+@model SpecializationsModel
+@{
+    ViewData["Title"] = "Specializations";
+}
+
+<style>
+    .specializations-container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .specializations-title {
+        color: #2c3e50;
+        text-align: center;
+        margin-bottom: 15px;
+        font-size: 2.5rem;
+        font-weight: bold;
+    }
+
+    .specializations-subtitle {
+        color: #7f8c8d;
+        text-align: center;
+        margin-bottom: 40px;
+        font-size: 1.1rem;
+    }
+
+    .specializations-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 25px;
+        padding: 10px;
+    }
+
+    .specialization-card {
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+        overflow: hidden;
+        transition: all 0.3s ease;
+        cursor: pointer;
+        text-decoration: none;
+        display: block;
+    }
+
+    .specialization-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+    }
+
+    .card-header {
+        background: linear-gradient(135deg, #8B0000 0%, #DC143C 100%);
+        color: white;
+        padding: 25px 20px;
+        position: relative;
+    }
+
+    .card-header h3 {
+        margin: 0;
+        font-size: 1.4rem;
+        font-weight: 600;
+    }
+
+    .card-header .icon {
+        font-size: 2.5rem;
+        position: absolute;
+        right: 20px;
+        top: 50%;
+        transform: translateY(-50%);
+        opacity: 0.3;
+    }
+
+    .card-body {
+        padding: 20px;
+    }
+
+    .card-body p {
+        color: #5d6d7e;
+        margin-bottom: 15px;
+        line-height: 1.6;
+    }
+
+    .card-stats {
+        display: flex;
+        justify-content: space-between;
+        border-top: 1px solid #ecf0f1;
+        padding-top: 15px;
+        margin-top: 10px;
+    }
+
+    .stat-item {
+        text-align: center;
+    }
+
+    .stat-value {
+        font-size: 1.3rem;
+        font-weight: bold;
+        color: #8B0000;
+    }
+
+    .stat-label {
+        font-size: 0.8rem;
+        color: #95a5a6;
+        text-transform: uppercase;
+    }
+
+    .view-details {
+        display: inline-block;
+        margin-top: 15px;
+        color: #8B0000;
+        font-weight: 600;
+        text-decoration: none;
+    }
+
+    .view-details:hover {
+        text-decoration: underline;
+    }
+
+    .intro-section {
+        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+        padding: 30px;
+        border-radius: 12px;
+        margin-bottom: 40px;
+        text-align: center;
+    }
+
+    .intro-section h2 {
+        color: #2c3e50;
+        margin-bottom: 15px;
+    }
+
+    .intro-section p {
+        color: #5d6d7e;
+        max-width: 800px;
+        margin: 0 auto;
+        line-height: 1.7;
+    }
+</style>
+
+<div class="specializations-container">
+    <h1 class="specializations-title">@ViewData["Title"]</h1>
+    <p class="specializations-subtitle">Comprehensive healthcare services tailored to your needs</p>
+
+    <div class="intro-section">
+        <h2>Excellence in Specialized Care</h2>
+        <p>At Contoso Clinic, our team of expert physicians provides world-class care across multiple specializations. 
+           Each department is equipped with state-of-the-art technology and staffed by board-certified specialists 
+           dedicated to delivering the highest quality patient outcomes.</p>
+    </div>
+
+    <div class="specializations-grid">
+        @foreach (var spec in Model.Specializations)
+        {
+            <a href="@spec.PageUrl" class="specialization-card">
+                <div class="card-header">
+                    <h3>@spec.Name</h3>
+                    <span class="icon">@spec.Icon</span>
+                </div>
+                <div class="card-body">
+                    <p>@spec.Description</p>
+                    <div class="card-stats">
+                        <div class="stat-item">
+                            <div class="stat-value">@spec.DoctorCount</div>
+                            <div class="stat-label">Doctors</div>
+                        </div>
+                        <div class="stat-item">
+                            <div class="stat-value">@spec.ServiceCount</div>
+                            <div class="stat-label">Services</div>
+                        </div>
+                        <div class="stat-item">
+                            <div class="stat-value">@spec.YearsEstablished+</div>
+                            <div class="stat-label">Years</div>
+                        </div>
+                    </div>
+                    <span class="view-details">Learn More →</span>
+                </div>
+            </a>
+        }
+    </div>
+</div>

--- a/src/Pages/Specializations.cshtml.cs
+++ b/src/Pages/Specializations.cshtml.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using contosohealth.Data;
+
+namespace contosohealth.Pages;
+
+public class SpecializationsModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public List<SpecializationInfo> Specializations { get; set; } = new List<SpecializationInfo>();
+
+    public SpecializationsModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        // Get distinct specializations from doctors and build department info
+        var doctorSpecializations = await _context.Doctors
+            .GroupBy(d => d.Specialization)
+            .Select(g => new { Specialization = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        // Define specialization details (would typically come from a database)
+        var specializationDetails = new Dictionary<string, (string Description, string Icon, int ServiceCount, int YearsEstablished, string PageUrl)>
+        {
+            ["Cardiology"] = ("Comprehensive heart and cardiovascular care including diagnostics, interventional procedures, and preventive cardiology.", "❤️", 15, 25, "/Specializations/Cardiology"),
+            ["Neurology"] = ("Expert diagnosis and treatment of disorders affecting the brain, spinal cord, and nervous system.", "🧠", 12, 20, "/Specializations/Neurology"),
+            ["Orthopedics"] = ("Complete musculoskeletal care from sports injuries to joint replacements and spine surgery.", "🦴", 18, 22, "/Specializations/Orthopedics"),
+            ["Pediatrics"] = ("Dedicated healthcare for infants, children, and adolescents in a child-friendly environment.", "👶", 14, 30, "/Specializations/Pediatrics"),
+            ["Dermatology"] = ("Medical and cosmetic skin care services including treatment for conditions and aesthetic procedures.", "✨", 10, 18, "/Specializations/Dermatology"),
+            ["Oncology"] = ("Comprehensive cancer care with advanced treatment options, clinical trials, and supportive services.", "🎗️", 20, 15, "/Specializations/Oncology"),
+            ["Gastroenterology"] = ("Specialized care for digestive system disorders including endoscopy and liver disease management.", "🫁", 11, 19, "/Specializations/Gastroenterology"),
+            ["Pulmonology"] = ("Expert respiratory care for conditions affecting the lungs and breathing.", "💨", 9, 17, "/Specializations/Pulmonology"),
+            ["Endocrinology"] = ("Treatment for hormone-related conditions including diabetes, thyroid disorders, and metabolic diseases.", "⚗️", 8, 16, "/Specializations/Endocrinology"),
+            ["Ophthalmology"] = ("Complete eye care services from routine exams to advanced surgical procedures.", "👁️", 13, 24, "/Specializations/Ophthalmology")
+        };
+
+        foreach (var spec in doctorSpecializations)
+        {
+            if (specializationDetails.TryGetValue(spec.Specialization, out var details))
+            {
+                Specializations.Add(new SpecializationInfo
+                {
+                    Name = spec.Specialization,
+                    Description = details.Description,
+                    Icon = details.Icon,
+                    DoctorCount = spec.Count,
+                    ServiceCount = details.ServiceCount,
+                    YearsEstablished = details.YearsEstablished,
+                    PageUrl = details.PageUrl
+                });
+            }
+            else
+            {
+                // For specializations not in our predefined list
+                Specializations.Add(new SpecializationInfo
+                {
+                    Name = spec.Specialization,
+                    Description = $"Quality healthcare services in {spec.Specialization}.",
+                    Icon = "🏥",
+                    DoctorCount = spec.Count,
+                    ServiceCount = 8,
+                    YearsEstablished = 10,
+                    PageUrl = $"/Specializations/{spec.Specialization.Replace(" ", "")}"
+                });
+            }
+        }
+
+        // Sort by name
+        Specializations = Specializations.OrderBy(s => s.Name).ToList();
+    }
+}
+
+public class SpecializationInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Icon { get; set; } = string.Empty;
+    public int DoctorCount { get; set; }
+    public int ServiceCount { get; set; }
+    public int YearsEstablished { get; set; }
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/src/Pages/Specializations/Cardiology.cshtml
+++ b/src/Pages/Specializations/Cardiology.cshtml
@@ -1,0 +1,366 @@
+@page
+@model contosohealth.Pages.Specializations.CardiologyModel
+@{
+    ViewData["Title"] = "Cardiology";
+}
+
+<style>
+    .cardiology-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .hero-section {
+        background: linear-gradient(135deg, #8B0000 0%, #DC143C 100%);
+        color: white;
+        padding: 50px 40px;
+        border-radius: 12px;
+        margin-bottom: 40px;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .hero-section::before {
+        content: "❤️";
+        font-size: 150px;
+        position: absolute;
+        right: 40px;
+        top: 50%;
+        transform: translateY(-50%);
+        opacity: 0.1;
+    }
+
+    .hero-section h1 {
+        font-size: 2.8rem;
+        margin-bottom: 15px;
+        font-weight: bold;
+    }
+
+    .hero-section p {
+        font-size: 1.2rem;
+        max-width: 600px;
+        opacity: 0.95;
+        line-height: 1.7;
+    }
+
+    .breadcrumb-nav {
+        margin-bottom: 20px;
+    }
+
+    .breadcrumb-nav a {
+        color: #8B0000;
+        text-decoration: none;
+    }
+
+    .breadcrumb-nav a:hover {
+        text-decoration: underline;
+    }
+
+    .breadcrumb-nav span {
+        color: #7f8c8d;
+    }
+
+    .section-title {
+        color: #2c3e50;
+        font-size: 1.8rem;
+        font-weight: bold;
+        margin-bottom: 25px;
+        padding-bottom: 10px;
+        border-bottom: 3px solid #8B0000;
+        display: inline-block;
+    }
+
+    .content-section {
+        margin-bottom: 50px;
+    }
+
+    .services-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        gap: 20px;
+    }
+
+    .service-card {
+        background: white;
+        border-radius: 10px;
+        padding: 25px;
+        box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+        transition: all 0.3s ease;
+        border-left: 4px solid #8B0000;
+    }
+
+    .service-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 6px 20px rgba(0,0,0,0.12);
+    }
+
+    .service-card h4 {
+        color: #2c3e50;
+        margin-bottom: 10px;
+        font-weight: 600;
+    }
+
+    .service-card p {
+        color: #5d6d7e;
+        font-size: 0.95rem;
+        line-height: 1.6;
+        margin: 0;
+    }
+
+    .conditions-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        gap: 15px;
+    }
+
+    .condition-item {
+        background: #f8f9fa;
+        padding: 15px 20px;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .condition-item::before {
+        content: "•";
+        color: #8B0000;
+        font-size: 1.5rem;
+        font-weight: bold;
+    }
+
+    .condition-item span {
+        color: #2c3e50;
+        font-weight: 500;
+    }
+
+    .procedures-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: white;
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+    }
+
+    .procedures-table thead {
+        background: linear-gradient(135deg, #8B0000 0%, #DC143C 100%);
+        color: white;
+    }
+
+    .procedures-table th {
+        padding: 15px 20px;
+        text-align: left;
+        font-weight: 600;
+    }
+
+    .procedures-table td {
+        padding: 15px 20px;
+        border-bottom: 1px solid #ecf0f1;
+        color: #2c3e50;
+    }
+
+    .procedures-table tbody tr:hover {
+        background-color: #f8f9fa;
+    }
+
+    .procedures-table tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    .procedure-type {
+        display: inline-block;
+        padding: 4px 10px;
+        border-radius: 15px;
+        font-size: 0.8rem;
+        font-weight: 500;
+    }
+
+    .procedure-type.diagnostic {
+        background: #e3f2fd;
+        color: #1976d2;
+    }
+
+    .procedure-type.interventional {
+        background: #fff3e0;
+        color: #f57c00;
+    }
+
+    .procedure-type.surgical {
+        background: #fce4ec;
+        color: #c2185b;
+    }
+
+    .stats-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 20px;
+        margin-bottom: 50px;
+    }
+
+    .stat-box {
+        background: white;
+        padding: 25px;
+        border-radius: 10px;
+        text-align: center;
+        box-shadow: 0 3px 10px rgba(0,0,0,0.08);
+    }
+
+    .stat-box .number {
+        font-size: 2.5rem;
+        font-weight: bold;
+        color: #8B0000;
+    }
+
+    .stat-box .label {
+        color: #7f8c8d;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        margin-top: 5px;
+    }
+
+    .contact-section {
+        background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+        padding: 30px;
+        border-radius: 12px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 20px;
+    }
+
+    .contact-info h3 {
+        color: #2c3e50;
+        margin-bottom: 10px;
+    }
+
+    .contact-info p {
+        color: #5d6d7e;
+        margin: 5px 0;
+    }
+
+    .appointment-btn {
+        background: linear-gradient(135deg, #8B0000 0%, #DC143C 100%);
+        color: white;
+        padding: 15px 30px;
+        border: none;
+        border-radius: 8px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        text-decoration: none;
+    }
+
+    .appointment-btn:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 15px rgba(139, 0, 0, 0.3);
+        color: white;
+    }
+
+    @@media (max-width: 768px) {
+        .stats-row {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        .hero-section::before {
+            display: none;
+        }
+    }
+</style>
+
+<div class="cardiology-container">
+    <nav class="breadcrumb-nav">
+        <a href="/Specializations">Specializations</a> <span> / Cardiology</span>
+    </nav>
+
+    <div class="hero-section">
+        <h1>Cardiology Department</h1>
+        <p>Our cardiology team provides comprehensive heart and cardiovascular care using the latest diagnostic 
+           technology and treatment methods. From preventive care to complex interventions, we're dedicated 
+           to keeping your heart healthy.</p>
+    </div>
+
+    <div class="stats-row">
+        <div class="stat-box">
+            <div class="number">@Model.DoctorCount</div>
+            <div class="label">Cardiologists</div>
+        </div>
+        <div class="stat-box">
+            <div class="number">15,000+</div>
+            <div class="label">Patients Annually</div>
+        </div>
+        <div class="stat-box">
+            <div class="number">98%</div>
+            <div class="label">Success Rate</div>
+        </div>
+        <div class="stat-box">
+            <div class="number">25+</div>
+            <div class="label">Years Experience</div>
+        </div>
+    </div>
+
+    <div class="content-section">
+        <h2 class="section-title">Our Services</h2>
+        <div class="services-grid">
+            @foreach (var service in Model.Services)
+            {
+                <div class="service-card">
+                    <h4>@service.Name</h4>
+                    <p>@service.Description</p>
+                </div>
+            }
+        </div>
+    </div>
+
+    <div class="content-section">
+        <h2 class="section-title">Conditions We Treat</h2>
+        <div class="conditions-list">
+            @foreach (var condition in Model.Conditions)
+            {
+                <div class="condition-item">
+                    <span>@condition</span>
+                </div>
+            }
+        </div>
+    </div>
+
+    <div class="content-section">
+        <h2 class="section-title">Procedures & Treatments</h2>
+        <table class="procedures-table">
+            <thead>
+                <tr>
+                    <th>Procedure</th>
+                    <th>Type</th>
+                    <th>Duration</th>
+                    <th>Recovery</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var procedure in Model.Procedures)
+                {
+                    <tr>
+                        <td><strong>@procedure.Name</strong></td>
+                        <td>
+                            <span class="procedure-type @procedure.Type.ToLower()">@procedure.Type</span>
+                        </td>
+                        <td>@procedure.Duration</td>
+                        <td>@procedure.Recovery</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+
+    <div class="contact-section">
+        <div class="contact-info">
+            <h3>Schedule an Appointment</h3>
+            <p>📞 Phone: (555) 123-HEART</p>
+            <p>📧 Email: cardiology@contosoclinic.com</p>
+            <p>📍 Location: Building A, 3rd Floor</p>
+        </div>
+        <a href="#" class="appointment-btn">Book Appointment</a>
+    </div>
+</div>

--- a/src/Pages/Specializations/Cardiology.cshtml.cs
+++ b/src/Pages/Specializations/Cardiology.cshtml.cs
@@ -1,0 +1,160 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using contosohealth.Data;
+
+namespace contosohealth.Pages.Specializations;
+
+public class CardiologyModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public int DoctorCount { get; set; }
+    public List<CardiologyService> Services { get; set; } = new List<CardiologyService>();
+    public List<string> Conditions { get; set; } = new List<string>();
+    public List<CardiologyProcedure> Procedures { get; set; } = new List<CardiologyProcedure>();
+
+    public CardiologyModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        // Get count of cardiologists from database
+        DoctorCount = await _context.Doctors
+            .CountAsync(d => d.Specialization == "Cardiology");
+
+        // If no cardiologists in DB, show a default count for demo purposes
+        if (DoctorCount == 0)
+        {
+            DoctorCount = 8;
+        }
+
+        // Initialize services offered
+        Services = new List<CardiologyService>
+        {
+            new CardiologyService
+            {
+                Name = "Preventive Cardiology",
+                Description = "Risk assessment, lifestyle counseling, and early detection programs to prevent heart disease before it starts."
+            },
+            new CardiologyService
+            {
+                Name = "Diagnostic Imaging",
+                Description = "Advanced cardiac imaging including echocardiography, CT angiography, and cardiac MRI for accurate diagnosis."
+            },
+            new CardiologyService
+            {
+                Name = "Interventional Cardiology",
+                Description = "Minimally invasive procedures including angioplasty, stent placement, and catheter-based treatments."
+            },
+            new CardiologyService
+            {
+                Name = "Electrophysiology",
+                Description = "Diagnosis and treatment of heart rhythm disorders, including pacemaker and defibrillator implantation."
+            },
+            new CardiologyService
+            {
+                Name = "Heart Failure Management",
+                Description = "Comprehensive care programs for patients with heart failure, including medication management and device therapy."
+            },
+            new CardiologyService
+            {
+                Name = "Cardiac Rehabilitation",
+                Description = "Structured exercise and education programs to help patients recover from heart events and surgery."
+            }
+        };
+
+        // Initialize conditions treated
+        Conditions = new List<string>
+        {
+            "Coronary Artery Disease",
+            "Heart Failure",
+            "Atrial Fibrillation",
+            "Hypertension",
+            "Heart Valve Disease",
+            "Cardiomyopathy",
+            "Peripheral Artery Disease",
+            "Congenital Heart Defects",
+            "Angina Pectoris",
+            "Arrhythmias",
+            "Pericarditis",
+            "Aortic Aneurysm"
+        };
+
+        // Initialize procedures
+        Procedures = new List<CardiologyProcedure>
+        {
+            new CardiologyProcedure
+            {
+                Name = "Echocardiogram",
+                Type = "Diagnostic",
+                Duration = "30-60 min",
+                Recovery = "None"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Cardiac Catheterization",
+                Type = "Diagnostic",
+                Duration = "1-2 hours",
+                Recovery = "4-6 hours"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Coronary Angioplasty",
+                Type = "Interventional",
+                Duration = "1-3 hours",
+                Recovery = "1-2 days"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Stent Placement",
+                Type = "Interventional",
+                Duration = "1-2 hours",
+                Recovery = "1-2 days"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Pacemaker Implantation",
+                Type = "Surgical",
+                Duration = "1-2 hours",
+                Recovery = "2-4 weeks"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Ablation Therapy",
+                Type = "Interventional",
+                Duration = "2-4 hours",
+                Recovery = "1-3 days"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Stress Test",
+                Type = "Diagnostic",
+                Duration = "30-60 min",
+                Recovery = "None"
+            },
+            new CardiologyProcedure
+            {
+                Name = "Holter Monitoring",
+                Type = "Diagnostic",
+                Duration = "24-48 hours",
+                Recovery = "None"
+            }
+        };
+    }
+}
+
+public class CardiologyService
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}
+
+public class CardiologyProcedure
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Duration { get; set; } = string.Empty;
+    public string Recovery { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
Add a new Specializations section to the website that provides an overview of all services our doctors offer, organized by department.

## Changes

### Main Specializations Page (`/Specializations`)
- Displays all unique specializations from the doctors database
- Each specialization shown as a card with:
  - Doctor count
  - Service count
  - Years established
  - Link to detailed subpage

### Cardiology Subpage (`/Specializations/Cardiology`)
- Hero section with department overview
- Statistics row (doctors, patients annually, success rate, years)
- 6 core services (Preventive Cardiology, Diagnostic Imaging, etc.)
- 12 conditions treated
- 8 procedures with type, duration, and recovery info
- Contact section with appointment CTA

### Navigation
- Added "Specializations" link to the main navigation bar

## Files Added
- `src/Pages/Specializations.cshtml` + `.cs`
- `src/Pages/Specializations/Cardiology.cshtml` + `.cs`

## Files Modified
- `src/Pages/Shared/_Layout.cshtml` - Added nav link

Closes #9